### PR TITLE
Use windowTitle instead of getModel in _cleaunup_panel

### DIFF
--- a/svgsynoptic2/taurussynopticwidget.py
+++ b/svgsynoptic2/taurussynopticwidget.py
@@ -305,8 +305,8 @@ class TaurusSynopticWidget(SynopticWidget, TaurusWidget):
         become pretty bogged down."""
         if self.registry:
             with self.registry.lock:
-                print "cleaning up panel for", w.getModel(), "..."
-                self._panels.pop(str(w.getModel()).lower(), None)
+                print "cleaning up panel for", w.windowTitle(), "..."
+                self._panels.pop(str(w.windowTitle()).lower(), None)
                 w.setModel(None)
                 print "done!"
 


### PR DESCRIPTION
If someone tries to setModel on not exported or somehow broken device, getModel returns empty string and TaurusDevicePanels is broken, so after trying to close the widget, it cannot find and remove it. Then, after reopening (even with restarted device) the panel, it finds broken widget again and doesn't try to open the new one.

`Name` is also used for setting window title and in this case it's always the same.